### PR TITLE
Buffer input timeouts

### DIFF
--- a/mod/lib/buffer-input.ms
+++ b/mod/lib/buffer-input.ms
@@ -40,13 +40,14 @@
     (cond ((string? evt) (string-append! buffer evt))
           ((eq? evt 'close) (reject 'close)
                             (error 'close))
+          ((eq? evt 'timeout) (reject 'timeout)
+                              (error 'timeout))
           (else (reject evt))))
 
   (define more (cond
                  (timeout (function (more/timed)
                             (define event (wait timeout source))
-                            (unless 
-                              (eq? event 'timeout) (process event))))
+                            (process event)))
                  (else (function (more/patient)
                           (define event (wait source))
                           (process event)))))
@@ -56,6 +57,7 @@
       (return (string-read! buffer (string-length buffer))))
     
     (catch-case (((close) (return 'close))
+                 ((timeout) (return 'timeout))
                   (else (re-error err)))
       (while (< (string-length buffer) amt)
         (more))


### PR DESCRIPTION
This commit contains a fix to 'buffer-input' so that it returns the symbol 'timeout if a timeout occurs. Current behaviour in MSOREF seems to require this. I modelled the fix after the way 'close is handled.

Connections made to a MOSREF console that do not send the preamble and just wait never time out. This commit fixes that. A smaller test case that shows the problem:

```
(import "lib/buffer-input")  
(import "lib/tcp-server")
(define out (current-output))
(define (handler)
   (define read (buffer-input (current-input) 5000))
   (define a (read 10))
   (send (format a) out)
   (send 'close (current-output)))
```

Without this fix, the above will not timeout and is instead stuck in the 'read' call when something connects to it.

I haven't included the buffer-input.mo file in the patch. I left it out since it might cause merge issues if you're merging into another repository with a newer .mo file. What's the best way of dealing with this? Should I include regenerated .mo's?
