### PR TITLE
Idle fix

### DIFF
--- a/vm/os.c
+++ b/vm/os.c
@@ -64,8 +64,14 @@ void wasp_disable_os_loop( ){
     if( -- wasp_os_loop_use ) return;
     wasp_disable_process( wasp_os_loop_process );
 }
-   
-void wasp_os_poll( ){ event_loop( EVLOOP_NONBLOCK | EVLOOP_ONCE ); }
+
+void wasp_os_poll( ){
+    if( wasp_enable_count == 1 ){
+        event_loop( EVLOOP_ONCE );
+    }else{
+        event_loop( EVLOOP_NONBLOCK | EVLOOP_ONCE ); 
+    }
+}
 
 void wasp_enable_conn_loop( wasp_os_connection oscon ){
     if( oscon->looping ) return;

--- a/vm/waspvm/process.h
+++ b/vm/waspvm/process.h
@@ -76,6 +76,8 @@ extern wasp_process wasp_first_enabled;
 extern wasp_process wasp_last_enabled;
 extern wasp_process wasp_active_process;
 
+extern wasp_quad wasp_enable_count;
+
 #define REQ_PROCESS_ARG( x ) REQ_TYPED_ARG( x, process )
 #define OPT_PROCESS_ARG( x ) OPT_TYPED_ARG( x, process )
 #define PROCESS_RESULT( x )  TYPED_RESULT( process, x )


### PR DESCRIPTION
On Linux I noticed the Wasp repl sitting idle was using about 6% CPU. The same with MOSREF and the drones also use about the same CPU percentage when idle.

This commit changes 'wasp_os_poll' so that it blocks waiting for an event if only one process is enabled. Given that we're already in the os poll process function this would mean that this is the only process so it's safe to block here as nothing else can run. This makes the repl, mosref and the drones idle at 0%. 
