### PR TITLE
Build system changes to allow Android cross compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 include Makefile.cf
 
+STRIP ?= strip
+
 WASPVM_EXE ?= $(ROOT)/stubs/waspvm-$(PLATFORM)$(EXE)
 WASPC_EXE ?= $(ROOT)/waspc$(EXE)
 WASP_EXE ?= $(ROOT)/wasp$(EXE)
@@ -22,7 +24,7 @@ LIBWASPVM ?= libwaspvm$(SO)
 
 $(WASPVM_EXE): vm/waspvm$(OBJ) $(WASPVM_OBJS) $(LIBRX)
 	$(CC) $(CFLAGS) $(LDFLAGS) $(WASPVM_OBJS) $< $(EXEFLAGS) -o $@
-	test z$(DEBUG) = z && strip $(WASPVM_EXE) || true
+	test z$(DEBUG) = z && $(STRIP) $(WASPVM_EXE) || true
 
 #TODO: This currently relies on a precompiled set of modules.
 $(WASPC_EXE): $(WASPVM_EXE) $(WASPLD_EXE)
@@ -68,7 +70,7 @@ objects: $(WASPVM_OBJS)
 
 %$(EXE): vm/%$(OBJ) $(WASPVM_OBJS)
 	$(CC) $(CFLAGS) $(LDFLAGS) $(WASPVM_OBJS) $< $(EXEFLAGS) -o $@
-	test z$(DEBUG) = z && strip $(WASPVM_EXE) || true
+	test z$(DEBUG) = z && $(STRIP) $(WASPVM_EXE) || true
 
 vm/%$(OBJ): vm/%.c
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c $< -o $@

--- a/Makefile.cf
+++ b/Makefile.cf
@@ -1,5 +1,5 @@
-OS=$(shell uname -s | sed 's:_.*::')
-ARCH=$(shell uname -m)
+OS?=$(shell uname -s | sed 's:_.*::')
+ARCH?=$(shell uname -m)
 ROOT=$(shell pwd)
 SYS=mod/sys
 
@@ -55,7 +55,9 @@ CFLAGS += -DWASP_SO='".so"'
 PLATFORM = unix
 ### An indirect dependency of libevent.
 ifneq ($(OS),Darwin)
+ifneq ($(OS),android)
 DYNAMICLIBS += -lrt
+endif
 endif
 
 endif


### PR DESCRIPTION
Some minor build changes to allow cross compilation to build Android executables. See [my post on building for Android](http://bluishcoder.co.nz/2013/05/09/building-wasp-lisp-and-mosref-for-android.html) to use.

It basically just allows overriding of the OS/PLATFORM/STRIP to the android SDK equivalents and stops '-lrt' if on Android.
