### PR TITLE
Fix argument count when using wasp shell routines

### DIFF
--- a/vm/shell.c
+++ b/vm/shell.c
@@ -68,7 +68,7 @@ wasp_connection wasp_spawn_cmd( wasp_string path, wasp_list arg, wasp_list var )
 
     wasp_os_error( socketpair( AF_LOCAL, SOCK_STREAM, 0, fds ) ); 
 
-    char** argv = wasp_make_argv( arg, argc );
+    char** argv = wasp_make_argv( arg, argc + 1);
     char** varv = varc ? wasp_make_argv( var, varc ) : environ;
 
     wasp_connection conn = (wasp_connection)wasp_make_os_connection( fds[0], 1 );


### PR DESCRIPTION
wasp_make_argv allocates an array of pointers using the
count passed to it. It then iterates over the list storing
pointers in the array. Since the list is one element greater
than the count due to the size being computed before the
executable name is prepended this results in an out of bounds
write.

Verified running wasp under valgrind. Originally noticed when
linking with the musl libc as it caused a segfault during the
out of bounds write.