### PR TITLE
Init static array and fix length in wasp_random_quad

### DIFF
--- a/vm/salsa.c
+++ b/vm/salsa.c
@@ -199,10 +199,10 @@ wasp_string wasp_read_prng( int req ){
 }
 
 wasp_quad wasp_random_quad( ){
-    char q[16];
+    char q[sizeof(wasp_quad)] = { 0 };
     salsa20_crypt( 
         & wasp_get_prng( )->context, 
-        q, q, 4 
+        q, q, sizeof(wasp_quad)
     );
     return *(wasp_quad*)q; 
 }


### PR DESCRIPTION
This prevents an uninitialized use report in valgrind. The static
array is uninitialized but used in salsa20_crypt when ^-ing the
input array element with the random data. As the input array and
output array are the same - the uninitialized array - there is a use
of uninitalized data here. This gets reported as a conditional
using uninitialized data later when the result of wasp_random_quad
is used in wasp_random_integer.

Test case is to run under valgrind and do "(wasp_random_integer 0 10)".

I've also changed the array to use the size of a wasp_quad and to request
sizeof(wasp_quad) data. Previously it requested 4 bytes whereas a
wasp_quad is 8 bytes on my system.