### PR TITLE
Fix type of vector length to be integer sized

### DIFF
--- a/vm/waspvm/vector.h
+++ b/vm/waspvm/vector.h
@@ -20,7 +20,7 @@
 #include "memory.h"
 
 WASP_BEGIN_TYPE( vector )
-    wasp_word  length;
+    wasp_integer  length;
     wasp_value data[0];
 WASP_END_TYPE( vector )
 #define REQ_VECTOR_ARG( vn ) REQ_TYPED_ARG( vn, vector )


### PR DESCRIPTION
The length was of type word which resulted in issues
when vectors greater than 65,535 elements were created
and then indexed. For example:

    (vector-length (make-vector 70000))
    => 4464