### PR TITLE
wasp_random_handle wasn't always returning a value

### DIFF
--- a/vm/salsa.c
+++ b/vm/salsa.c
@@ -137,10 +137,10 @@ int wasp_get_random_handle( ){
     if( wasp_random_handle ) return wasp_random_handle;
 
     wasp_random_handle = open( "/dev/urandom", O_RDONLY );
-    if( wasp_random_handle > 0 ) return;
+    if( wasp_random_handle > 0 ) return wasp_random_handle;
     
     wasp_random_handle = open( "/dev/random", O_RDONLY );
-    if( wasp_random_handle > 0 ) return;
+    if( wasp_random_handle > 0 ) return wasp_random_handle;
 
     wasp_random_handle = 0;
     wasp_errf( wasp_es_vm, "s", "could not open OS entropy source" );


### PR DESCRIPTION
wasp_random_handle had early returns that didn't return
an expected 'int' value. This would result in sporadic
hangs of calls to 'random_integer' and other functions
that obtained entropy.